### PR TITLE
Unions may have empty traces

### DIFF
--- a/src/utils/TraceUtils.js
+++ b/src/utils/TraceUtils.js
@@ -60,14 +60,6 @@ export const constructUnionTrace = (traceArray1, traceArray2) => {
         throw new Error('second array is undefined');
     }
 
-    if (traceArray1.length === 0) {
-        throw new Error('first array is empty');
-    }
-
-    if (traceArray2.length === 0) {
-        throw new Error('second array is empty');
-    }
-
     if (traceArray1.includes(null)) {
         throw new Error('first array contains null values');
     }

--- a/src/utils/TraceUtils.test.js
+++ b/src/utils/TraceUtils.test.js
@@ -176,16 +176,6 @@ describe('constructUnionTrace', () => {
         },
     };
 
-    it('throws when first array is empty', () => {
-        const emptyArr = [];
-        expect(constructUnionTrace_(emptyArr, arr1)).toThrow('first array is empty');
-    })
-
-    it('throws when first array is empty', () => {
-        const emptyArr = [];
-        expect(constructUnionTrace_(arr1, emptyArr)).toThrow('second array is empty');
-    })
-
     it('throws when first array is null', () => {
         expect(constructUnionTrace_(null, arr1)).toThrow('first array is null');
     });


### PR DESCRIPTION
We don't currently do that, ever, but it is in principle fine, and
should not be ruled out for no apparent reason.

For example, we have discussed maybe using Unions with empty traces to
encode expressions that do not come from the source code, for
example the expressions in the preamble.